### PR TITLE
fix: validation text on role-crud module

### DIFF
--- a/packages/identity/identity-vue/src/cruds/role-crud/RoleForm.vue
+++ b/packages/identity/identity-vue/src/cruds/role-crud/RoleForm.vue
@@ -67,7 +67,7 @@ const {
               prepend-inner-icon="mdi-card-account-details"
               :variant="variant"
               :error-messages="$ta(store.inputErrors?.name)"
-              :rules="[v => !!v || 'validation.required']"
+              :rules="[v => !!v || t('validation.required')]"
               density="default"
               :readonly="readonly"
               :clearable="false"


### PR DESCRIPTION
El texto de validación en el formulario "Role" es literalmente "validation.required" en vez de tomar el valor real de i18n