### PR TITLE
feat: Password complexity rule

### DIFF
--- a/packages/identity/identity-front/src/i18n/identity-validation-i18n.ts
+++ b/packages/identity/identity-front/src/i18n/identity-validation-i18n.ts
@@ -5,11 +5,17 @@ const messages = {
                 invalid: 'Invalid Email',
             },
             password: {
+                complexity: 'Password is invalid, it must contain: ',
                 min8: 'Password must be at least 8 characters long',
                 max32: 'Password must be at most 32 characters long',
                 max64: 'Password must be at most 64 characters long',
                 confirmed: 'Passwords do not match',
-                currentDifferent: 'New password must be different from current password'
+                currentDifferent: 'New password must be different from current password',
+                MinChar: 'Minimum characters: ',
+                MinLowerCase: 'Lowercase required: ',
+                MinUppercase: 'Uppercase required: ',
+                MinNumber: 'Numbers required: ',
+                MinSymbol: 'Symbols required: ',
             },
         }
     },
@@ -19,11 +25,17 @@ const messages = {
                 invalid: 'Email invalido',
             },
             password:{
+                complexity: 'La contraseña es inválida, debe contener: ',
                 min8: 'La contraseña debe tener al menos 8 caracteres',
                 max32: 'La contraseña debe tener como maximo 32 caracteres',
                 max64: 'La contraseña debe tener como maximo 64 caracteres',
                 confirmed: 'Las contraseñas no coinciden',
-                currentDifferent: 'Nueva contraseña debe ser diferente de la actual'
+                currentDifferent: 'Nueva contraseña debe ser diferente de la actual',
+                MinChar: 'Caracteres minimos: ',
+                MinLowerCase: 'Minusculas requeridas: ',
+                MinUppercase: 'Mayusculas requeridas: ',
+                MinNumber: 'Numeros requeridos: ',
+                MinSymbol: 'Simbolos requeridos: ',
             },
         }
     }

--- a/packages/identity/identity-vue/src/components/IdentityChangeOwnPassword/IdentityChangeOwnPassword.vue
+++ b/packages/identity/identity-vue/src/components/IdentityChangeOwnPassword/IdentityChangeOwnPassword.vue
@@ -5,11 +5,14 @@ import {ClientError} from "@drax/common-front";
 import type {IClientInputError} from "@drax/common-front";
 import {useI18nValidation} from "@drax/common-vue";
 import {useI18n} from "vue-i18n";
+import { usePasswordValidation } from "../../composables/usePasswordValidation";
 
 const {t,te} = useI18n()
 const {$ta} = useI18nValidation()
 
 const {changeOwnPassword} = useAuth()
+
+const { passwordRulesState, passwordComplexityRule } = usePasswordValidation()
 
 const currentPassword = ref('')
 const newPassword = ref('')
@@ -22,16 +25,21 @@ const changed = ref(false)
 let currentPasswordVisibility = ref(false)
 let newPasswordVisibility = ref(false)
 
-const isFormValid = computed(() =>
-    currentPassword.value.trim() !== '' && newPassword.value.trim() !== ''
-    && newPassword.value.trim() === confirmPassword.value.trim()
-)
+const isFormValid = computed(() => {
+  if (!currentPassword.value.trim() || !newPassword.value.trim() || !confirmPassword.value.trim()) return false
+  if (newPassword.value.trim() !== confirmPassword.value.trim()) return false
+  return passwordComplexityRule(newPassword.value) === true
+})
 
 function confirmPasswordRule(value: string) {
   return newPassword.value.trim() === confirmPassword.value.trim() || t('validation.password.confirmed')
 }
 
+const passwordRules = computed(() => passwordRulesState(newPassword.value))
+
 async function submitChangePassword() {
+  if (!isFormValid.value) return
+
   try {
     loading.value = true
     await changeOwnPassword(currentPassword.value.trim(), newPassword.value.trim())
@@ -97,7 +105,19 @@ async function submitChangePassword() {
                     @click:append-inner="newPasswordVisibility = !newPasswordVisibility"
                     autocomplete="new-password"
                     :error-messages="$ta(inputErrors?.newPassword)"
+                    :rules="[passwordComplexityRule]"
                 ></v-text-field>
+                <div v-if="passwordRules.length">
+                  <div v-for="(rule, index) in passwordRules" :key="index" class="d-flex align-center">
+                    <v-icon :color="rule.valid ? 'success' : 'grey'" size="18" class="mr-2">
+                      {{ rule.valid ? 'mdi-check-circle' : 'mdi-circle-outline' }}
+                    </v-icon>
+
+                    <span :class="rule.valid ? 'text-success' : 'text-grey'">
+                      {{ rule.label }}
+                    </span>
+                  </div>
+                </div>
                 <div class="text-subtitle-1 text-medium-emphasis">{{ t('user.field.confirmPassword') }}</div>
                 <v-text-field
                     variant="outlined"

--- a/packages/identity/identity-vue/src/components/IdentityRecoveryPasswordComplete/IdentityRecoveryPasswordComplete.vue
+++ b/packages/identity/identity-vue/src/components/IdentityRecoveryPasswordComplete/IdentityRecoveryPasswordComplete.vue
@@ -1,35 +1,38 @@
 <script setup lang="ts">
-import {computed, ref, onMounted} from 'vue'
-import {useAuth} from "../../composables/useAuth.js";
-import {ClientError} from "@drax/common-front";
-import type {IClientInputError} from "@drax/common-front";
-import {useI18nValidation} from "@drax/common-vue";
-import {useI18n} from "vue-i18n";
-import {useRoute, useRouter} from "vue-router"
+import { computed, ref, onMounted } from 'vue'
+import { useAuth } from "../../composables/useAuth.js";
+import { ClientError } from "@drax/common-front";
+import type { IClientInputError } from "@drax/common-front";
+import { useI18nValidation } from "@drax/common-vue";
+import { useI18n } from "vue-i18n";
+import { useRoute, useRouter } from "vue-router"
+import { usePasswordValidation } from "../../composables/usePasswordValidation";
 
-const {t,te} = useI18n()
-const {$ta} = useI18nValidation()
+const { t, te } = useI18n()
+const { $ta } = useI18nValidation()
+
+const { passwordRulesState, passwordComplexityRule } = usePasswordValidation()
 
 const route = useRoute()
 const router = useRouter()
 
-const {recoveryPasswordComplete} = useAuth()
+const { recoveryPasswordComplete } = useAuth()
 
 const recoveryCode = ref('')
 const newPassword = ref('')
 const confirmPassword = ref('')
-const inputErrors = ref<IClientInputError|undefined>({currentPassword: [], newPassword: [], confirmPassword: []})
+const inputErrors = ref<IClientInputError | undefined>({ currentPassword: [], newPassword: [], confirmPassword: [] })
 const errorMsg = ref('')
 const loading = ref(false)
 const success = ref(false)
 
 let newPasswordVisibility = ref(false)
 
-
-const isFormValid = computed(() =>
-    recoveryCode.value.trim() !== '' && newPassword.value.trim() !== ''
-    && newPassword.value.trim() === confirmPassword.value.trim()
-)
+const isFormValid = computed(() => {
+  if (!recoveryCode.value.trim() || !newPassword.value.trim() || !confirmPassword.value.trim()) return false
+  if (newPassword.value.trim() !== confirmPassword.value.trim()) return false
+  return passwordComplexityRule(newPassword.value) === true
+})
 
 const recoveryCodeParam = computed(() => {
   return route.params.code
@@ -45,7 +48,11 @@ function confirmPasswordRule(value: string) {
   return newPassword.value.trim() === confirmPassword.value.trim() || t('validation.password.confirmed')
 }
 
+const passwordRules = computed(() => passwordRulesState(newPassword.value))
+
 async function submitResetPassword() {
+  if (!isFormValid.value) return
+
   try {
     loading.value = true
     await recoveryPasswordComplete(recoveryCode.value.trim(), newPassword.value.trim())
@@ -53,7 +60,7 @@ async function submitResetPassword() {
   } catch (err) {
     if (err instanceof ClientError) {
       inputErrors.value = err.inputErrors
-    }if(err instanceof Error) {
+    } if (err instanceof Error) {
       errorMsg.value = err.message
     }
     const error = err as Error
@@ -85,73 +92,55 @@ async function submitResetPassword() {
 
     <template v-else>
 
-          <v-form @submit.prevent="submitResetPassword">
-            <v-card variant="elevated">
-              <v-card-title class="pa-4">{{ t('user.action.recoveryPassword') }}</v-card-title>
-              <v-card-text v-if="errorMsg">
-                <v-alert type="error">
-                  {{ te(errorMsg) ?t(errorMsg) : errorMsg }}
-                </v-alert>
-              </v-card-text>
-              <v-card-text>
-                <div class="text-subtitle-1 text-medium-emphasis">{{ t('user.field.recoveryCode') }}</div>
-                <v-text-field
-                    variant="outlined"
-                    id="recovery-code-input"
-                    v-model="recoveryCode"
-                    prepend-inner-icon="mdi-code-braces-box"
-                    required
-                    readonly
-                    :error-messages="$ta(inputErrors?.recoveryCode)"
-                ></v-text-field>
+      <v-form @submit.prevent="submitResetPassword">
+        <v-card variant="elevated">
+          <v-card-title class="pa-4">{{ t('user.action.recoveryPassword') }}</v-card-title>
+          <v-card-text v-if="errorMsg">
+            <v-alert type="error">
+              {{ te(errorMsg) ? t(errorMsg) : errorMsg }}
+            </v-alert>
+          </v-card-text>
+          <v-card-text>
+            <div class="text-subtitle-1 text-medium-emphasis">{{ t('user.field.recoveryCode') }}</div>
+            <v-text-field variant="outlined" id="recovery-code-input" v-model="recoveryCode"
+              prepend-inner-icon="mdi-code-braces-box" required readonly
+              :error-messages="$ta(inputErrors?.recoveryCode)"></v-text-field>
 
-                <div class="text-subtitle-1 text-medium-emphasis">{{ t('user.field.newPassword') }}</div>
-                <!-- NEW PASSWORD-->
-                <v-text-field
-                    variant="outlined"
-                    id="new-password-input"
-                    v-model="newPassword"
-                    :type="newPasswordVisibility ? 'text': 'password'"
-                    required
-                    prepend-inner-icon="mdi-lock-outline"
-                    :append-inner-icon="newPasswordVisibility ? 'mdi-eye-off': 'mdi-eye'"
-                    @click:append-inner="newPasswordVisibility = !newPasswordVisibility"
-                    autocomplete="new-password"
-                    :error-messages="$ta(inputErrors?.newPassword)"
-                ></v-text-field>
-                <div class="text-subtitle-1 text-medium-emphasis">{{ t('user.field.confirmPassword') }}</div>
-                <!-- CONFIRM PASSWORD-->
-                <v-text-field
-                    variant="outlined"
-                    id="confirm-password-input"
-                    v-model="confirmPassword"
-                    :type="newPasswordVisibility ? 'text': 'password'"
-                    required
-                    prepend-inner-icon="mdi-lock-outline"
-                    :append-inner-icon="newPasswordVisibility ? 'mdi-eye-off': 'mdi-eye'"
-                    @click:append-inner="newPasswordVisibility = !newPasswordVisibility"
-                    autocomplete="new-password"
-                    :error-messages="$ta(inputErrors?.confirmPassword)"
-                    :rules="[confirmPasswordRule]"
-                ></v-text-field>
-              </v-card-text>
-              <v-card-actions>
-                <v-spacer></v-spacer>
-                <v-btn
-                    class="mb-8"
-                    color="blue"
-                    size="large"
-                    variant="tonal"
-                    id="submit-button"
-                    type="submit"
-                    block
-                    :disabled="!isFormValid"
-                >
-                  {{ t('action.sent') }}
-                </v-btn>
-              </v-card-actions>
-            </v-card>
-          </v-form>
+            <div class="text-subtitle-1 text-medium-emphasis">{{ t('user.field.newPassword') }}</div>
+            <!-- NEW PASSWORD-->
+            <v-text-field variant="outlined" id="new-password-input" v-model="newPassword"
+              :type="newPasswordVisibility ? 'text' : 'password'" required prepend-inner-icon="mdi-lock-outline"
+              :append-inner-icon="newPasswordVisibility ? 'mdi-eye-off' : 'mdi-eye'"
+              @click:append-inner="newPasswordVisibility = !newPasswordVisibility" autocomplete="new-password"
+              :error-messages="$ta(inputErrors?.newPassword)" :rules="[passwordComplexityRule]"></v-text-field>
+            <div v-if="passwordRules.length">
+              <div v-for="(rule, index) in passwordRules" :key="index" class="d-flex align-center">
+                <v-icon :color="rule.valid ? 'success' : 'grey'" size="18" class="mr-2">
+                  {{ rule.valid ? 'mdi-check-circle' : 'mdi-circle-outline' }}
+                </v-icon>
+
+                <span :class="rule.valid ? 'text-success' : 'text-grey'">
+                  {{ rule.label }}
+                </span>
+              </div>
+            </div>
+            <div class="text-subtitle-1 text-medium-emphasis">{{ t('user.field.confirmPassword') }}</div>
+            <!-- CONFIRM PASSWORD-->
+            <v-text-field variant="outlined" id="confirm-password-input" v-model="confirmPassword"
+              :type="newPasswordVisibility ? 'text' : 'password'" required prepend-inner-icon="mdi-lock-outline"
+              :append-inner-icon="newPasswordVisibility ? 'mdi-eye-off' : 'mdi-eye'"
+              @click:append-inner="newPasswordVisibility = !newPasswordVisibility" autocomplete="new-password"
+              :error-messages="$ta(inputErrors?.confirmPassword)" :rules="[confirmPasswordRule]"></v-text-field>
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer></v-spacer>
+            <v-btn class="mb-8" color="blue" size="large" variant="tonal" id="submit-button" type="submit" block
+              :disabled="!isFormValid">
+              {{ t('action.sent') }}
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-form>
     </template>
   </v-sheet>
 </template>

--- a/packages/identity/identity-vue/src/components/IdentityRegistration/IdentityRegistration.vue
+++ b/packages/identity/identity-vue/src/components/IdentityRegistration/IdentityRegistration.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import {ref} from 'vue'
+import {ref, computed} from 'vue'
 import {useAuth} from "../../composables/useAuth.js";
 import {ClientError} from "@drax/common-front";
 import type {IClientInputError} from "@drax/common-front";
 import {useI18nValidation} from "@drax/common-vue";
 import {useI18n} from "vue-i18n";
 import {useRouter} from "vue-router"
+import { usePasswordValidation } from "../../composables/usePasswordValidation";
 
 const {t,te} = useI18n()
 const {$ta} = useI18nValidation()
@@ -13,6 +14,8 @@ const {$ta} = useI18nValidation()
 const router = useRouter()
 
 const {register} = useAuth()
+
+const { passwordRulesState, passwordComplexityRule } = usePasswordValidation()
 
 const variant = ref<"outlined" | "plain" | "filled" | "underlined" | "solo" | "solo-inverted" | "solo-filled" | undefined>('filled')
 
@@ -33,12 +36,21 @@ const success = ref(false)
 let passwordVisibility = ref(false)
 let confirmPasswordVisibility = ref(false)
 
+const isFormValid = computed(() => {
+  if (!form.value.password || !form.value.confirmPassword) return false
+  if (form.value.password.trim() !== form.value.confirmPassword.trim()) return false
+  return passwordComplexityRule(form.value.password) === true
+})
 
 function confirmPasswordRule(value: string) {
   return form.value.password.trim() === form.value.confirmPassword.trim() || t('validation.password.confirmed')
 }
 
+const passwordRules = computed(() => passwordRulesState(form.value.password))
+
 async function submitRegistration() {
+  if (!isFormValid.value) return
+  
   try {
     loading.value = true
     const result = await register(form.value)
@@ -144,7 +156,19 @@ async function submitRegistration() {
                     @click:append-inner="passwordVisibility = !passwordVisibility"
                     autocomplete="new-password"
                     :error-messages="$ta(inputErrors?.newPassword)"
+                    :rules="[passwordComplexityRule]"
                 ></v-text-field>
+                <div v-if="passwordRules.length">
+                  <div v-for="(rule, index) in passwordRules" :key="index" class="d-flex align-center">
+                    <v-icon :color="rule.valid ? 'success' : 'grey'" size="18" class="mr-2">
+                      {{ rule.valid ? 'mdi-check-circle' : 'mdi-circle-outline' }}
+                    </v-icon>
+
+                    <span :class="rule.valid ? 'text-success' : 'text-grey'">
+                      {{ rule.label }}
+                    </span>
+                  </div>
+                </div>
                 <div class="text-subtitle-1 text-medium-emphasis">{{ t('user.field.confirmPassword') }}</div>
                 <!-- CONFIRM PASSWORD-->
                 <v-text-field
@@ -179,6 +203,7 @@ async function submitRegistration() {
                     id="submit-button"
                     type="submit"
                     :loading="loading"
+                    :disabled="!isFormValid"
                 >
                   {{ t('action.sent') }}
                 </v-btn>

--- a/packages/identity/identity-vue/src/composables/usePasswordValidation.ts
+++ b/packages/identity/identity-vue/src/composables/usePasswordValidation.ts
@@ -1,0 +1,143 @@
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useSetting } from '@drax/settings-vue'
+
+interface PasswordRule {
+  label: string
+  valid: boolean
+}
+
+
+const DEFAULT_SETTINGS = {
+  passwordMinLength: 8,
+  passwordRequireLowercase: 0,
+  passwordRequireUppercase: 0,
+  passwordSymbolsAllowed: '!@#$%^&*',
+  passwordRequireSymbols: 0,
+  passwordRequireNumbers: 0
+}
+
+export function usePasswordValidation() {
+  const { t } = useI18n()
+  const { settings } = useSetting()
+
+  const config = computed(() => {
+    const s = settings.value || []
+    
+    const numericKeys = [
+      'passwordMinLength',
+      'passwordRequireLowercase',
+      'passwordRequireUppercase',
+      'passwordRequireSymbols',
+      'passwordRequireNumbers'
+    ]
+    
+    const getSetting = (key: string, defaultValue: any) => {
+      const found = s.find((setting: any) => setting.key === key)
+      if (!found) return defaultValue
+      
+      if (numericKeys.includes(key)) {
+        return Number(found.value) || defaultValue
+      }
+      
+      return found.value
+    }
+
+    return {
+      minLength: getSetting('passwordMinLength', DEFAULT_SETTINGS.passwordMinLength),
+      requireLowercase: getSetting('passwordRequireLowercase', DEFAULT_SETTINGS.passwordRequireLowercase),
+      requireUppercase: getSetting('passwordRequireUppercase', DEFAULT_SETTINGS.passwordRequireUppercase),
+      symbolsAllowed: getSetting('passwordSymbolsAllowed', DEFAULT_SETTINGS.passwordSymbolsAllowed),
+      requireSymbols: getSetting('passwordRequireSymbols', DEFAULT_SETTINGS.passwordRequireSymbols),
+      requireNumbers: getSetting('passwordRequireNumbers', DEFAULT_SETTINGS.passwordRequireNumbers)
+    }
+  })
+
+  const passwordRulesState = (password: string): PasswordRule[] => {
+    const pwd = password || ''
+    const rules: PasswordRule[] = []
+
+    const countLowercase = (pwd.match(/[a-z]/g) || []).length
+    const countUppercase = (pwd.match(/[A-Z]/g) || []).length
+    const countNumbers = (pwd.match(/[0-9]/g) || []).length
+    
+    const symbolsAllowed = config.value.symbolsAllowed || ''
+    const symbolsRegex = symbolsAllowed ? new RegExp(`[${symbolsAllowed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}]`, 'g') : null
+    const countSymbols = symbolsRegex ? (pwd.match(symbolsRegex) || []).length : 0
+
+    rules.push({
+      label: `${t('validation.password.MinChar')} ${config.value.minLength}`,
+      valid: pwd.length >= config.value.minLength
+    })
+
+    if (config.value.requireLowercase > 0) {
+      rules.push({
+        label: `${t('validation.password.MinLowerCase')} ${config.value.requireLowercase}`,
+        valid: countLowercase >= config.value.requireLowercase
+      })
+    }
+
+    if (config.value.requireUppercase > 0) {
+      rules.push({
+        label: `${t('validation.password.MinUppercase')} ${config.value.requireUppercase}`,
+        valid: countUppercase >= config.value.requireUppercase
+      })
+    }
+
+    if (config.value.requireNumbers > 0) {
+      rules.push({
+        label: `${t('validation.password.MinNumber')} ${config.value.requireNumbers}`,
+        valid: countNumbers >= config.value.requireNumbers
+      })
+    }
+
+    if (config.value.requireSymbols > 0 && symbolsAllowed) {
+      rules.push({
+        label: `${t('validation.password.MinSymbol')} ${config.value.requireSymbols} (${symbolsAllowed})`,
+        valid: countSymbols >= config.value.requireSymbols
+      })
+    }
+
+    return rules
+  }
+
+  const passwordComplexityRule = (value: string): boolean | string => {
+    if (!value) return true
+
+    const pwd = value.trim()
+    const rules = passwordRulesState(pwd)
+
+    const allValid = rules.every(rule => rule.valid)
+
+    if (!allValid) {
+      const invalidLabels = rules
+        .filter(rule => !rule.valid)
+        .map(rule => rule.label)
+        .join(', ')
+      return `${t('validation.password.complexity')} ${invalidLabels}`
+    }
+
+    return true
+  }
+
+  const validatePassword = (password: string): boolean => {
+    if (!password) return false
+    const pwd = password.trim()
+    const rules = passwordRulesState(pwd)
+    return rules.every(rule => rule.valid)
+  }
+
+  const getInvalidRules = (password: string): PasswordRule[] => {
+    if (!password) return []
+    const pwd = password.trim()
+    return passwordRulesState(pwd).filter(rule => !rule.valid)
+  }
+
+  return {
+    config,
+    passwordRulesState,
+    passwordComplexityRule,
+    validatePassword,
+    getInvalidRules
+  }
+}

--- a/packages/identity/identity-vue/src/cruds/user-crud/UserForm.vue
+++ b/packages/identity/identity-vue/src/cruds/user-crud/UserForm.vue
@@ -1,20 +1,22 @@
 <script setup lang="ts">
-import {useFormUtils, useCrudStore} from "@drax/crud-vue";
-import {computed, ref} from "vue";
-import {useI18nValidation} from "@drax/common-vue";
+import { useFormUtils, useCrudStore } from "@drax/crud-vue";
+import { computed, ref } from "vue";
+import { useI18nValidation } from "@drax/common-vue";
 import RoleCombobox from "../../combobox/RoleCombobox.vue";
 import TenantCombobox from "../../combobox/TenantCombobox.vue";
-import {useAuth} from "../../composables/useAuth";
-import {useI18n} from "vue-i18n";
-import {useIdentityCrudStore} from "../../stores/IdentityCrudStore";
+import { useAuth } from "../../composables/useAuth";
+import { useI18n } from "vue-i18n";
+import { useIdentityCrudStore } from "../../stores/IdentityCrudStore";
+import { usePasswordValidation } from "../../composables/usePasswordValidation";
 
-const {$ta} = useI18nValidation()
-const {t, te} = useI18n()
+const { passwordComplexityRule } = usePasswordValidation()
+const { $ta } = useI18nValidation()
+const { t, te } = useI18n()
 
-const {hasPermission} = useAuth()
+const { hasPermission } = useAuth()
 
 
-const valueModel = defineModel({type: [Object]})
+const valueModel = defineModel({ type: [Object] })
 
 const emit = defineEmits(['submit', 'cancel'])
 
@@ -32,13 +34,11 @@ const formRef = ref()
 // Add this computed property
 const isTenantEnabled = computed(() => import.meta.env.VITE_DRAX_TENANT === 'ENABLE')
 
-
-
 async function submit() {
   store.resetErrors()
 
-  if(store.operation === 'delete') {
-    emit('submit',valueModel.value)
+  if (store.operation === 'delete') {
+    emit('submit', valueModel.value)
     return
   }
 
@@ -55,7 +55,7 @@ function cancel() {
 }
 
 const {
-   submitColor, readonly
+  submitColor, readonly
 } = useFormUtils(store.operation)
 
 
@@ -93,112 +93,51 @@ let passwordVisibility = ref(false)
 
       <v-card-text>
 
-        <v-text-field
-            id="name-input"
-            :label="t('user.field.name')"
-            v-model="valueModel.name"
-            prepend-inner-icon="mdi-card-account-details"
-            :variant="variant"
-            :rules="[v => !!v || t('validation.required')]"
-            :error-messages="$ta(store.inputErrors?.name)"
-            :readonly="readonly"
-        ></v-text-field>
+        <v-text-field id="name-input" :label="t('user.field.name')" v-model="valueModel.name"
+          prepend-inner-icon="mdi-card-account-details" :variant="variant"
+          :rules="[v => !!v || t('validation.required')]" :error-messages="$ta(store.inputErrors?.name)"
+          :readonly="readonly"></v-text-field>
 
-        <v-text-field
-            id="username-input"
-            :label="t('user.field.username')"
-            v-model="valueModel.username"
-            prepend-inner-icon="mdi-account-question"
-            :variant="variant"
-            :rules="[v => !!v || t('validation.required')]"
-            autocomplete="new-username"
-            :error-messages="$ta(store.inputErrors?.username)"
-            :readonly="readonly"
-        ></v-text-field>
+        <v-text-field id="username-input" :label="t('user.field.username')" v-model="valueModel.username"
+          prepend-inner-icon="mdi-account-question" :variant="variant" :rules="[v => !!v || t('validation.required')]"
+          autocomplete="new-username" :error-messages="$ta(store.inputErrors?.username)"
+          :readonly="readonly"></v-text-field>
 
-        <v-text-field
-            v-if="enablePassword"
-            id="password-input"
-            :label="t('user.field.password')"
-            v-model="valueModel.password"
-            :type="passwordVisibility ? 'text': 'password'"
-            :variant="variant"
-            :rules="[v => !!v || t('validation.required')]"
-            prepend-inner-icon="mdi-lock-outline"
-            :append-inner-icon="passwordVisibility ? 'mdi-eye-off': 'mdi-eye'"
-            @click:append-inner="passwordVisibility = !passwordVisibility"
-            autocomplete="new-password"
-            :error-messages="$ta(store.inputErrors?.password)"
-            :readonly="readonly"
-        ></v-text-field>
+        <v-text-field v-if="enablePassword" id="password-input" :label="t('user.field.password')"
+          v-model="valueModel.password" :type="passwordVisibility ? 'text' : 'password'" :variant="variant"
+          :rules="[v => !!v || t('validation.required'), passwordComplexityRule]" prepend-inner-icon="mdi-lock-outline"
+          :append-inner-icon="passwordVisibility ? 'mdi-eye-off' : 'mdi-eye'"
+          @click:append-inner="passwordVisibility = !passwordVisibility" autocomplete="new-password"
+          :error-messages="$ta(store.inputErrors?.password)" :readonly="readonly"></v-text-field>
 
-        <RoleCombobox
-            v-model="valueModel.role"
-            :label="t('user.field.role')"
-            :variant="variant"
-            :rules="[(v:any) => !!v || t('validation.required')]"
-            :error-messages="$ta(store.inputErrors?.role)"
-            :readonly="readonly"
-        ></RoleCombobox>
+        <RoleCombobox v-model="valueModel.role" :label="t('user.field.role')" :variant="variant"
+          :rules="[(v: any) => !!v || t('validation.required')]" :error-messages="$ta(store.inputErrors?.role)"
+          :readonly="readonly"></RoleCombobox>
 
-        <TenantCombobox
-            v-if="isTenantEnabled && hasPermission('tenant:manage')"
-            v-model="valueModel.tenant"
-            :label="t('user.field.tenant')"
-            :variant="variant"
-            :error-messages="$ta(store.inputErrors?.tenant)"
-            clearable
-            :readonly="readonly"
-        ></TenantCombobox>
+        <TenantCombobox v-if="isTenantEnabled && hasPermission('tenant:manage')" v-model="valueModel.tenant"
+          :label="t('user.field.tenant')" :variant="variant" :error-messages="$ta(store.inputErrors?.tenant)" clearable
+          :readonly="readonly"></TenantCombobox>
 
-        <v-text-field
-            v-model="valueModel.email"
-            :variant="variant"
-            id="email-input"
-            :label="t('user.field.email')"
-            prepend-inner-icon="mdi-email"
-            :rules="[(v:any) => !!v || t('validation.required')]"
-            :error-messages="$ta(store.inputErrors?.email)"
-            :readonly="readonly"
-        ></v-text-field>
+        <v-text-field v-model="valueModel.email" :variant="variant" id="email-input" :label="t('user.field.email')"
+          prepend-inner-icon="mdi-email" :rules="[(v: any) => !!v || t('validation.required')]"
+          :error-messages="$ta(store.inputErrors?.email)" :readonly="readonly"></v-text-field>
 
-        <v-text-field
-            v-model="valueModel.phone"
-            :variant="variant"
-            id="phone-input"
-            :label="t('user.field.phone')"
-            prepend-inner-icon="mdi-phone"
-            :rules="[(v:any) => !!v || t('validation.required')]"
-            :error-messages="$ta(store.inputErrors?.phone)"
-            :readonly="readonly"
-        ></v-text-field>
+        <v-text-field v-model="valueModel.phone" :variant="variant" id="phone-input" :label="t('user.field.phone')"
+          prepend-inner-icon="mdi-phone" :rules="[(v: any) => !!v || t('validation.required')]"
+          :error-messages="$ta(store.inputErrors?.phone)" :readonly="readonly"></v-text-field>
 
-        <v-switch
-            id="active-input"
-            v-model="valueModel.active"
-            color="primary"
-            label="Active"
-            :true-value="true"
-            :false-value="false"
-            :readonly="readonly"
-        ></v-switch>
+        <v-switch id="active-input" v-model="valueModel.active" color="primary" label="Active" :true-value="true"
+          :false-value="false" :readonly="readonly"></v-switch>
 
       </v-card-text>
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn
-            variant="text"
-            color="grey"
-            @click="cancel">
+        <v-btn variant="text" color="grey" @click="cancel">
           {{ t('action.cancel') }}
         </v-btn>
-        <v-btn
-            v-if="!valueModel.readonly && store.operation != 'view'"
-            variant="flat"
-            :color="submitColor"
-            @click="submit"
-        >
+        <v-btn v-if="!valueModel.readonly && store.operation != 'view'" variant="flat" :color="submitColor"
+          @click="submit">
           {{ store.operation ? t('action.' + store.operation) : t('action.sent') }}
         </v-btn>
       </v-card-actions>
@@ -206,6 +145,4 @@ let passwordVisibility = ref(false)
   </v-form>
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/packages/identity/identity-vue/src/cruds/user-crud/UserPasswordDialog.vue
+++ b/packages/identity/identity-vue/src/cruds/user-crud/UserPasswordDialog.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import UserPasswordForm from "./UserPasswordForm.vue";
-import { type PropType, ref} from "vue";
+import { type PropType, ref, computed } from "vue";
 import type {IUserPassword} from "@drax/identity-front";
 import type {IUser} from "@drax/identity-share";
 import {UserSystemFactory} from "@drax/identity-front";
 import {ClientError, type IClientInputError} from "@drax/common-front";
 import {useI18n} from "vue-i18n";
+import { usePasswordValidation } from "../../composables/usePasswordValidation";
 
 const {t} = useI18n()
 
@@ -17,13 +18,22 @@ const {user} = defineProps({
 
 const userSystem = UserSystemFactory.getInstance()
 
-let passwordForm = ref<IUserPassword>({newPassword: "", confirmPassword: ""})
-let passwordChanged = ref(false);
-let inputErrors = ref<IClientInputError>()
-let loading = ref(false);
-let userError = ref<string>('')
+ const { passwordComplexityRule } = usePasswordValidation()
+ let passwordForm = ref<IUserPassword>({newPassword: "", confirmPassword: ""})
+ let passwordChanged = ref(false);
+ let inputErrors = ref<IClientInputError>()
+ let loading = ref(false);
+ let userError = ref<string>('')
+
+const isFormValid = computed(() => {
+  const { newPassword, confirmPassword } = passwordForm.value
+  if (!newPassword || !confirmPassword) return false
+  if (newPassword !== confirmPassword) return false
+  return passwordComplexityRule(newPassword) === true
+})
 
 async function savePassword() {
+  if (!isFormValid.value) return
   if (passwordForm.value.newPassword === passwordForm.value.confirmPassword) {
     await changeUserPassword(user._id, passwordForm.value.newPassword)
     passwordChanged.value = true
@@ -77,6 +87,7 @@ async function changeUserPassword(id: string, newPassword: string) {
             color="primary"
             @click="savePassword"
             :loading="loading"
+            :disabled="!isFormValid"
         >
           {{ t('action.change') }}
         </v-btn>

--- a/packages/identity/identity-vue/src/cruds/user-crud/UserPasswordForm.vue
+++ b/packages/identity/identity-vue/src/cruds/user-crud/UserPasswordForm.vue
@@ -1,20 +1,22 @@
 <script setup lang="ts">
-import {ref, type PropType} from "vue";
-import type {IClientInputError} from "@drax/common-front";
-import type {IUserPassword} from "@drax/identity-front";
-import {useI18nValidation} from "@drax/common-vue";
-import {useI18n} from "vue-i18n";
+import { computed, ref, type PropType } from "vue";
+import type { IClientInputError } from "@drax/common-front";
+import type { IUserPassword } from "@drax/identity-front";
+import { useI18nValidation } from "@drax/common-vue";
+import { useI18n } from "vue-i18n";
+import { usePasswordValidation } from "../../composables/usePasswordValidation";
 
-const {t} = useI18n()
-const {$ta} = useI18nValidation()
+const { t } = useI18n()
+const { $ta } = useI18nValidation()
+
+const { passwordRulesState, passwordComplexityRule } = usePasswordValidation()
 
 let newPasswordVisibility = ref(false)
-
 
 defineProps({
   inputErrors: {
     type: Object as PropType<IClientInputError>,
-    default: () => ({id: "", newPassword: ""})
+    default: () => ({ id: "", newPassword: "" })
   },
   passwordChanged: {
     type: Boolean,
@@ -24,20 +26,27 @@ defineProps({
 
 const form = defineModel<IUserPassword>({
   type: Object as PropType<IUserPassword>,
-  default: () => ({newPassword: "", confirmPassword: ""})
+  default: () => ({ newPassword: "", confirmPassword: "" })
+})
+
+const isFormValid = computed(() => {
+  if (!form.value.newPassword || !form.value.confirmPassword) return false
+  if (form.value.newPassword !== form.value.confirmPassword) return false
+  return passwordComplexityRule(form.value.newPassword) === true
 })
 
 function confirmPasswordRule(value: string) {
   return form.value.newPassword === form.value.confirmPassword || t('validation.password.confirmed')
 }
 
-// Define emits
-const emits = defineEmits(['formSubmit'])
+const passwordRules = computed(() => passwordRulesState(form.value.newPassword))
 
-// Function to call when form is attempted to be submitted
-const onSubmit = () => {
-  emits('formSubmit', form); // Emitting an event with the form data
+function onSubmit() {
+  if (!isFormValid.value) return
 }
+
+defineExpose({ isFormValid })
+
 </script>
 
 <template>
@@ -51,39 +60,34 @@ const onSubmit = () => {
     <form ref="changeUserPassword" @submit.prevent="onSubmit">
 
       <div class="text-subtitle-1 text-medium-emphasis">{{ t('user.field.newPassword') }}</div>
-      <v-text-field
-          variant="outlined"
-          id="new-password-input"
-          v-model="form.newPassword"
-          :type="newPasswordVisibility ? 'text': 'password'"
-          required
-          prepend-inner-icon="mdi-lock-outline"
-          :append-inner-icon="newPasswordVisibility ? 'mdi-eye-off': 'mdi-eye'"
-          @click:append-inner="newPasswordVisibility = !newPasswordVisibility"
-          autocomplete="new-password"
-          :error-messages="$ta(inputErrors.newPassword)"
-      ></v-text-field>
+      <v-text-field variant="outlined" id="new-password-input" v-model="form.newPassword"
+        :type="newPasswordVisibility ? 'text' : 'password'" required prepend-inner-icon="mdi-lock-outline"
+        :append-inner-icon="newPasswordVisibility ? 'mdi-eye-off' : 'mdi-eye'"
+        @click:append-inner="newPasswordVisibility = !newPasswordVisibility" autocomplete="new-password"
+        :error-messages="$ta(inputErrors.newPassword)" :rules="[passwordComplexityRule]"></v-text-field>
+
+      <div v-if="passwordRules.length">
+        <div v-for="(rule, index) in passwordRules" :key="index" class="d-flex align-center">
+          <v-icon :color="rule.valid ? 'success' : 'grey'" size="18" class="mr-2">
+            {{ rule.valid ? 'mdi-check-circle' : 'mdi-circle-outline' }}
+          </v-icon>
+
+          <span :class="rule.valid ? 'text-success' : 'text-grey'">
+            {{ rule.label }}
+          </span>
+        </div>
+      </div>
 
       <div class="text-subtitle-1 text-medium-emphasis">{{ t('user.field.confirmPassword') }}</div>
 
-      <v-text-field
-          variant="outlined"
-          id="confirm-password-input"
-          v-model="form.confirmPassword"
-          :type="newPasswordVisibility ? 'text': 'password'"
-          required
-          prepend-inner-icon="mdi-lock-outline"
-          :append-inner-icon="newPasswordVisibility ? 'mdi-eye-off': 'mdi-eye'"
-          @click:append-inner="newPasswordVisibility = !newPasswordVisibility"
-          autocomplete="new-password"
-          :error-messages="$ta(inputErrors.confirmPassword)"
-          :rules="[confirmPasswordRule]"
-      ></v-text-field>
+      <v-text-field variant="outlined" id="confirm-password-input" v-model="form.confirmPassword"
+        :type="newPasswordVisibility ? 'text' : 'password'" required prepend-inner-icon="mdi-lock-outline"
+        :append-inner-icon="newPasswordVisibility ? 'mdi-eye-off' : 'mdi-eye'"
+        @click:append-inner="newPasswordVisibility = !newPasswordVisibility" autocomplete="new-password"
+        :error-messages="$ta(inputErrors.confirmPassword)" :rules="[confirmPasswordRule]"></v-text-field>
     </form>
   </v-sheet>
 
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>


### PR DESCRIPTION
 Implementación de validación de complejidad de contraseñas configurable vía settings.

Cambios principales:
- Nuevo composable usePasswordValidation() que permite validar contraseñas según configuración
- Settings de contraseña:
  - passwordMinLength - longitud mínima
  - passwordRequireLowercase - mínimo de minúsculas
  - passwordRequireUppercase - mínimo de mayúsculas  
  - passwordSymbolsAllowed - caracteres especiales permitidos
  - passwordRequireSymbols - mínimo de símbolos
  - passwordRequireNumbers - mínimo de números
- Mensaje de error dinámico que lista los requisitos no cumplidos (ej: "La contraseña es inválida, debe contener: mínimo 8 caracteres, mínimo 1 mayúscula")