### PR TITLE
fix(identity): fallback en audit user para eventos de auditoría pre-autenticación

### DIFF
--- a/packages/identity/identity-back/src/controllers/UserController.ts
+++ b/packages/identity/identity-back/src/controllers/UserController.ts
@@ -129,8 +129,14 @@ class UserController extends AbstractFastifyController<IUser, IUserCreate, IUser
         }
     }
 
-    async onUserEvent(request: CustomRequest, action: string, resourceId: string = null, detail: string = null) {
+    async onUserEvent(request: CustomRequest, action: string, resourceId: string = null, detail: string = null, userOverride: { id?: string, username?: string } | null = null) {
         const requestData = this.extractRequestData(request)
+        if ((!requestData.user.id || !requestData.user.username) && userOverride) {
+            requestData.user = {
+                ...requestData.user,
+                ...userOverride,
+            }
+        }
         const eventData: IDraxCrudEvent = {
             action: action,
             entity: this.entityName,
@@ -376,7 +382,7 @@ class UserController extends AbstractFastifyController<IUser, IUserCreate, IUser
             }
 
             const detail = `User ${user?.username} request a password recovery .`;
-            this.onUserEvent(request, 'passwordRecoveryRequest', user?._id, detail)
+            this.onUserEvent(request, 'passwordRecoveryRequest', user?._id, detail, {id: user?._id?.toString(), username: user?.username})
 
             reply.send({message})
 
@@ -408,7 +414,7 @@ class UserController extends AbstractFastifyController<IUser, IUserCreate, IUser
             const user: IUser = await userService.changeUserPasswordByCode(recoveryCode, newPassword)
             if (user) {
                 const detail = `User ${user?.username} complete a password recovery .`;
-                this.onUserEvent(request, 'passwordRecoveryCompleted', user?._id, detail)
+                this.onUserEvent(request, 'passwordRecoveryCompleted', user?._id, detail, {id: user?._id?.toString(),username: user?.username,})
                 reply.send({message: 'action.success'})
             } else {
                 reply.statusCode = 400


### PR DESCRIPTION
### FIX
Se detectó una falla en @drax/identity-back, UserController.onUserEvent() arma auditoría con request.rbac, pero en flujos prelogin (**passwordRecoveryRequest y recoveryPasswordComplete**) rbac.userId/username vienen undefined, devolviendo ZodError.

### PROPUESTA
El fix mínimo es permitir que onUserEvent() reciba un userOverride opcional y usar ese override en recovery request con el usuario resuelto por email.

### SOLUCIÓN
Corrige la generación de eventos de auditoría en flujos preautenticados. onUserEvent ahora prioriza el usuario presente en la request y, si no existe, usa el auditUser explícito, evitando ZodError en passwordRecoveryRequest y recoveryPasswordComplete sin cambiar el contrato actual de auditoría.